### PR TITLE
Fix missing Adj Close data from yfinance

### DIFF
--- a/bt-trading.py
+++ b/bt-trading.py
@@ -98,6 +98,7 @@ class DataManager:
                 all_symbols,
                 start=start_extended,
                 end=self.config.end_date,
+                auto_adjust=False,
                 progress=False
             )
 


### PR DESCRIPTION
## Summary
- ensure `Adj Close` column is returned by disabling `auto_adjust` in `yf.download`

## Testing
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('bt', 'bt-trading.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
config = mod.BacktestConfig(); config.end_date='2024-01-05'; config.start_date='2023-12-01'; config.assets=['SPY']
data = mod.DataManager(config).fetch_data()
print('assets:', list(data.keys()))
print('SPY head:', data['SPY'].head())
PY`

------
https://chatgpt.com/codex/tasks/task_e_687d269d2ccc8328a4ce41f8b9cab84d